### PR TITLE
Fix bug that __all__ is not defined

### DIFF
--- a/packagediscovery/__init__.py
+++ b/packagediscovery/__init__.py
@@ -1,5 +1,12 @@
 """Top-level package for Package Discovery."""
 
+from packagediscovery.packages import *  # noqa: F403
+from packagediscovery.setuptools import *  # noqa: F403
+
 __author__ = """Yukihiko Shinoda"""
 __email__ = "yuk.hik.future@gmail.com"
 __version__ = "0.1.0"
+
+__all__ = []
+__all__ += packages.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable
+__all__ += setuptools.__all__  # type:ignore[name-defined] # noqa: F405 pylint: disable=undefined-variable

--- a/packagediscovery/packages.py
+++ b/packagediscovery/packages.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+__all__ = ["Packages"]
+
 
 @dataclass
 class PairPackage:

--- a/packagediscovery/setuptools.py
+++ b/packagediscovery/setuptools.py
@@ -10,6 +10,8 @@ from setuptools.discovery import ConfigDiscovery
 from setuptools.discovery import FlatLayoutModuleFinder
 from setuptools.dist import Distribution
 
+__all__ = ["Setuptools"]
+
 
 class Setuptools:
     """To access dist."""


### PR DESCRIPTION
This pull request updates the package initialization and module exports to improve how the `packagediscovery` package exposes its submodules and classes. The main changes ensure that the public API is explicitly defined and that imports are managed more cleanly.

**Improvements to package exports and public API:**

* Updated `packagediscovery/__init__.py` to import all public symbols from `packagediscovery.packages` and `packagediscovery.setuptools`, and to build the `__all__` list dynamically from those submodules.
* Added explicit `__all__` lists to `packagediscovery/packages.py` (exports `Packages`) and `packagediscovery/setuptools.py` (exports `Setuptools`) to define their public interfaces. [[1]](diffhunk://#diff-12f6e445a1a24b8e7a6b81832f0eb89ec396aa0d9dc613b35b5cb1b01216cabcR7-R8) [[2]](diffhunk://#diff-5d23b5e406f245b442aa80ad3d6daf5f42642fc4d46cebdbed69ea2d94b00edfR13-R14)