### PR TITLE
Change interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,98 @@ Package discovery based on Setuptools.
 
 ## Advantage
 
-* TODO
+1. Debug packages that Setuptools discovered
+2. Easy to filter packages to root packages only
+
+### 1. Debug packages that Setuptools discovered
+
+You can check the discovered packages by running the following Python code.
+
+print_packages.py:
+
+```python
+from packagediscovery import Setuptools
+
+print(Setuptools().packages)
+```
+
+```bash
+$ python print_packages.py
+['packagediscovery']
+```
+
+Since Package Discovery settings of Setuptools is a bit complicated so that we may want to know what packages Setuptools are discovering now.
+
+cf. [Package Discovery and Namespace Packages - setuptools documentation]
+
+### 2. Easy to filter packages to root packages only
+
+You can filter the discovered packages to only include root packages by using the `root_packages` property.
+
+filter_packages.py:
+
+```python
+from packagediscovery import Packages, Setuptools
+
+setuptools = Setuptools()
+print(f"Packages = {setuptools.packages}")
+print(f"Root packages = {Packages(setuptools.packages).list_roots_only}")
+```
+
+```bash
+$ python filter_packages.py
+Packages = ['pyvelocity', 'pyvelocity.checks', 'pyvelocity.configurations', 'pyvelocity.configurations.files', 'pyvelocity.configurations.files.sections', 'pyvelocity.configurations.files.sections.pylint', 'pyvelocity.configurations.tools', 'pyvelocity.configurations.files.sections.pylint', 'pyvelocity.configurations.files.sections', 'pyvelocity.configurations.files', 'pyvelocity.checks', 'pyvelocity.configurations.tools', 'pyvelocity.configurations']
+Root packages = ['pyvelocity']
+```
 
 ## Quickstart
 
-* TODO
+Install the package
+
+```bash
+$ pip install packagediscovery
+```
 
 <!-- markdownlint-disable no-trailing-punctuation -->
 ## How do I...
 <!-- markdownlint-enable no-trailing-punctuation -->
 
-* TODO
+### Discover packages
+
+```python
+from packagediscovery import Setuptools
+
+setuptools = Setuptools()
+print(f"Packages = {setuptools.packages}")
+```
+
+### Discover py modules
+
+```python
+from packagediscovery import Setuptools
+
+setuptools = Setuptools()
+print(f"Py modules = {setuptools.py_modules}")
+```
+
+### Discover project root
+
+```python
+from packagediscovery import Setuptools
+
+setuptools = Setuptools()
+print(f"Project root = {setuptools.project_root}")
+```
+
+### Filter packages to root packages only
+
+```python
+from packagediscovery import Setuptools
+
+setuptools = Setuptools()
+print(f"Packages = {setuptools.packages}")
+print(f"Root packages = {Packages(setuptools.packages).list_roots_only}")
+```
 
 ## Credits
 
@@ -30,3 +111,4 @@ This package was created with [Cookiecutter] and the [yukihiko-shinoda/cookiecut
 
 [Cookiecutter]: https://github.com/audreyr/cookiecutter
 [yukihiko-shinoda/cookiecutter-pypackage]: https://github.com/audreyr/cookiecutter-pypackage
+[Package Discovery and Namespace Packages - setuptools documentation]: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

--- a/tests/test_setuptools.py
+++ b/tests/test_setuptools.py
@@ -23,6 +23,7 @@ class TestSetuptools:
         ],
     )
     def test_py_modules(self, py_modules: list[str] | None, expected: list[str]) -> None:
+        """The property: py_modules should be set appropriate py modules."""
         setuptools = Setuptools()
         # Reason: For testing pylint: disable=protected-access
         setuptools._py_modules = py_modules  # noqa: SLF001 # pyright: ignore[reportPrivateUsage]
@@ -31,7 +32,8 @@ class TestSetuptools:
     def test_packages(self) -> None:
         assert Setuptools().packages, ["packagediscovery"]
 
-    def test_find_py_modules_without_py_modules(self) -> None:
+    def test_modules_to_lint(self) -> None:
+        """The property: py_modules should not be excluded the packages that is set by modules_to_lint."""
         modules_to_lint = [
             "setup",
             "conftest",


### PR DESCRIPTION
This pull request improves the usability and documentation of the package discovery functionality, refactors the `Setuptools` class for better clarity, and updates the corresponding tests for robustness and coverage. The most important changes are grouped below:

**Documentation improvements:**

* Expanded the `README.md` to provide clear instructions and examples for debugging discovered packages, filtering to root packages, and using key features such as discovering packages, modules, and project root. Added references to relevant Setuptools documentation.

**Refactoring and feature enhancements in `Setuptools`:**

* Refactored the `Setuptools` class to store the distribution and py_modules internally, added a `modules_to_lint` parameter to customize module exclusion, and replaced the `find_py_modules` method with a `py_modules` property for easier access and caching.

**Testing improvements:**

* Updated and expanded tests in `tests/test_setuptools.py` to use parameterized testing for the `py_modules` property, improved coverage for edge cases, and adapted tests to the refactored API.
* Added necessary imports (`__future__` annotations and `pytest`) for improved test compatibility and type checking.